### PR TITLE
Add command to download and cache lists.

### DIFF
--- a/internal/package/fetcher/all.go
+++ b/internal/package/fetcher/all.go
@@ -1,0 +1,118 @@
+package fetcher
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/umutphp/awesome-cli/internal/package/node"
+	"github.com/umutphp/awesome-cli/internal/package/parser"
+)
+
+const DOWNLOAD_CONCURRENCY = 4
+
+type Progress struct {
+	Found uint64
+	Crawled uint64
+	Errors uint64
+}
+
+func FetchAllRepos(update chan Progress) (Progress, error) {
+	fetched, err := FetchAwesomeRootRepo()
+	if err != nil {
+		return Progress{1, 0, 1}, err
+	}
+
+	root := parser.ParseIndex(fetched)
+	urls := getAllChildrenURLs(root.GetChildren())
+
+	progress := Progress{
+		Found: uint64(1 + len(urls)),
+		Crawled: 1,
+		Errors: 0,
+	}
+	update <- progress
+
+	var wg sync.WaitGroup
+	queue := make(chan string)
+	errors := make(chan error)
+
+	for i := 0; i < 4; i++ {
+		go fetchWorker(queue, errors, &wg)
+	}
+
+	allErrors := MultiError{[]error{}}
+	go func () {
+		for err := range errors {
+			if err == nil {
+				progress.Crawled = progress.Crawled + 1
+			} else {
+				progress.Errors = progress.Errors + 1
+				allErrors.Errors = append(allErrors.Errors, err)
+			}
+			update <- progress
+		}
+		close(update)
+	}()
+
+	for _, url := range urls {
+		queue <- url
+	}
+
+	close(queue)
+	wg.Wait()
+	close(errors)
+
+	if len(allErrors.Errors) == 0 {
+		return progress, nil
+	}
+	return progress, allErrors
+}
+
+func getAllChildrenURLs(children []node.Node) []string {
+	urls := []string{}
+	for _, child := range children {
+		if child.GetURL() != "" {
+			urls = append(urls, child.GetURL())
+		}
+		urls = append(urls, getAllChildrenURLs(child.GetChildren())...)
+	}
+	return urls
+}
+
+type MultiError struct {
+	Errors []error
+}
+
+func (e MultiError) Error() string {
+	errStrings := []string{}
+	for _, err := range e.Errors {
+		errStrings = append(errStrings, err.Error())
+	}
+	return strings.Join(errStrings, "\n")
+}
+
+type FetchError struct {
+	URL string
+	Wrapped error
+}
+
+func (e FetchError) Unwrap() error {
+	return e.Wrapped
+}
+
+func (e FetchError) Error() string {
+	return fmt.Sprintf("failed to fetch %q: %v", e.URL, e.Wrapped)
+}
+
+func fetchWorker(queue chan string, errors chan error, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+	for url := range queue {
+		if _, err := FetchAwesomeRepo(url); err != nil {
+			errors <- FetchError{url, err}
+		} else {
+			errors <- nil
+		}
+	}
+}

--- a/internal/package/progress/progress.go
+++ b/internal/package/progress/progress.go
@@ -1,0 +1,24 @@
+package progress
+
+import (
+	"fmt"
+
+	"github.com/umutphp/awesome-cli/internal/package/fetcher"
+)
+
+func ProgressBar(done chan struct{}, updates chan fetcher.Progress) {
+	for progress := range updates {
+		percent := 100.0 * float64(progress.Crawled + progress.Errors) / float64(progress.Found)
+		fmt.Print("\n\033[1A\033[K")
+		fmt.Print("[")
+		for i := 0; i < 20; i++ {
+			if float64(i*5) <= percent {
+				fmt.Print("=")
+			} else {
+				fmt.Print(" ")
+			}
+		}
+		fmt.Printf("] % 3.0f%%", percent)
+	}
+	close(done)
+}


### PR DESCRIPTION
I took a pass at #4, would love to iterate on this if you have feedback.

- [x]  Add an option to the cli
- [x]  When the option is given, all the repository information is downloaded to the cache recursively
- [x]  Inform user that the operation will take a long time
- [x]  Give the number of repositories cached when the operation is finished
- [x]  Display progress information (the repository being fetched etc)
- [x]  Use go routines to make the repository fetch in parallel (4 go routines)

Here's a demo run starting with a mostly complete cache:

![cache](https://user-images.githubusercontent.com/115059/139344809-fa50cb86-998c-4036-8699-570fb8b7afb0.gif)

